### PR TITLE
プルリクエストAPIエンドポイントの追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -923,6 +923,65 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.0.tgz",
+      "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.8.tgz",
@@ -1614,6 +1673,15 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
     },
+    "node_modules/@types/redis": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-4.0.10.tgz",
+      "integrity": "sha512-7CLy5b5fzzEGVcOccgZjoMlNpPhX6d10jEeRy2YWbFuaMNrSPc9ExRsMYsd+0VxvEHucf4EWx24Ja7cSU1FGUA==",
+      "license": "MIT",
+      "dependencies": {
+        "redis": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -2046,6 +2114,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -2790,6 +2867,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -4172,6 +4258,10 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis": {
+      "resolved": "src/redis",
+      "link": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4759,10 +4849,11 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4966,6 +5057,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -5527,6 +5624,50 @@
         "content-type": "^1.0.5",
         "raw-body": "^3.0.0",
         "zod": "^3.23.8"
+      }
+    },
+    "src/redis": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^0.4.0",
+        "@types/redis": "^4.0.10",
+        "redis": "^4.7.0"
+      },
+      "bin": {
+        "redis": "build/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "src/redis/node_modules/@modelcontextprotocol/sdk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.4.0.tgz",
+      "integrity": "sha512-79gx8xh4o9YzdbtqMukOe5WKzvEZpvBA1x8PAgJWL7J5k06+vJx8NK2kWzOazPgqnfDego7cNEO8tjai/nOPAA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "src/redis/node_modules/redis": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.0.tgz",
+      "integrity": "sha512-zvmkHEAdGMn+hMRXuMBtu4Vo5P6rHQjLoHftu+lBqq8ZTA3RCVC/WzD790bkKKiNFp7d5/9PcSD19fJyyRvOdQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.0",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "src/sequentialthinking": {

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -149,6 +149,51 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "get_issue",
         description: "Get details of a specific issue in a GitHub repository.",
         inputSchema: zodToJsonSchema(issues.GetIssueSchema)
+      },
+      {
+        name: "get_pull_request",
+        description: "Get details of a specific pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestSchema),
+      },
+      {
+        name: "list_pull_requests",
+        description: "List and filter repository pull requests",
+        inputSchema: zodToJsonSchema(pulls.ListPullRequestsSchema),
+      },
+      {
+        name: "create_pull_request_review",
+        description: "Create a review on a pull request",
+        inputSchema: zodToJsonSchema(pulls.CreatePullRequestReviewSchema),
+      },
+      {
+        name: "merge_pull_request",
+        description: "Merge a pull request",
+        inputSchema: zodToJsonSchema(pulls.MergePullRequestSchema),
+      },
+      {
+        name: "get_pull_request_files",
+        description: "Get the list of files changed in a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestFilesSchema),
+      },
+      {
+        name: "get_pull_request_status",
+        description: "Get the combined status of all status checks for a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestStatusSchema),
+      },
+      {
+        name: "update_pull_request_branch",
+        description: "Update a pull request branch with the latest changes from the base branch",
+        inputSchema: zodToJsonSchema(pulls.UpdatePullRequestBranchSchema),
+      },
+      {
+        name: "get_pull_request_comments",
+        description: "Get the review comments on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestCommentsSchema),
+      },
+      {
+        name: "get_pull_request_reviews",
+        description: "Get the reviews on a pull request",
+        inputSchema: zodToJsonSchema(pulls.GetPullRequestReviewsSchema),
       }
     ],
   };
@@ -332,6 +377,95 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const issue = await issues.getIssue(args.owner, args.repo, args.issue_number);
         return {
           content: [{ type: "text", text: JSON.stringify(issue, null, 2) }],
+        };
+      }
+
+      case "get_pull_request": {
+        const args = pulls.GetPullRequestSchema.parse(request.params.arguments);
+        const pullRequest = await pulls.getPullRequest(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequest, null, 2) }],
+        };
+      }
+
+      case "list_pull_requests": {
+        const args = pulls.ListPullRequestsSchema.parse(request.params.arguments);
+        const pullRequests = await pulls.listPullRequests(args.owner, args.repo, {
+          state: args.state,
+          sort: args.sort,
+          direction: args.direction,
+          head: args.head,
+          base: args.base,
+          page: args.page,
+          per_page: args.per_page
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(pullRequests, null, 2) }],
+        };
+      }
+
+      case "create_pull_request_review": {
+        const args = pulls.CreatePullRequestReviewSchema.parse(request.params.arguments);
+        const review = await pulls.createPullRequestReview(args.owner, args.repo, args.pull_number, {
+          body: args.body,
+          event: args.event,
+          comments: args.comments,
+          commit_id: args.commit_id
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(review, null, 2) }],
+        };
+      }
+
+      case "merge_pull_request": {
+        const args = pulls.MergePullRequestSchema.parse(request.params.arguments);
+        const result = await pulls.mergePullRequest(args.owner, args.repo, args.pull_number, {
+          commit_title: args.commit_title,
+          commit_message: args.commit_message,
+          merge_method: args.merge_method
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_files": {
+        const args = pulls.GetPullRequestFilesSchema.parse(request.params.arguments);
+        const files = await pulls.getPullRequestFiles(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(files, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_status": {
+        const args = pulls.GetPullRequestStatusSchema.parse(request.params.arguments);
+        const status = await pulls.getPullRequestStatus(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(status, null, 2) }],
+        };
+      }
+
+      case "update_pull_request_branch": {
+        const args = pulls.UpdatePullRequestBranchSchema.parse(request.params.arguments);
+        const result = await pulls.updatePullRequestBranch(args.owner, args.repo, args.pull_number, args.expected_head_sha);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_comments": {
+        const args = pulls.GetPullRequestCommentsSchema.parse(request.params.arguments);
+        const comments = await pulls.getPullRequestComments(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(comments, null, 2) }],
+        };
+      }
+
+      case "get_pull_request_reviews": {
+        const args = pulls.GetPullRequestReviewsSchema.parse(request.params.arguments);
+        const reviews = await pulls.getPullRequestReviews(args.owner, args.repo, args.pull_number);
+        return {
+          content: [{ type: "text", text: JSON.stringify(reviews, null, 2) }],
         };
       }
 


### PR DESCRIPTION
このPRでは、GitHubのプルリクエスト関連のAPIエンドポイントを追加しています。

追加されたエンドポイント:
- get_pull_request: 特定のプルリクエストの詳細を取得
- list_pull_requests: リポジトリのプルリクエスト一覧を取得
- create_pull_request_review: プルリクエストにレビューを作成
- merge_pull_request: プルリクエストをマージ
- get_pull_request_files: プルリクエストで変更されたファイル一覧を取得
- get_pull_request_status: プルリクエストのステータスチェック状態を取得
- update_pull_request_branch: プルリクエストブランチをベースブランチで更新
- get_pull_request_comments: プルリクエストのコメントを取得
- get_pull_request_reviews: プルリクエストのレビューを取得